### PR TITLE
Fix unused arguments

### DIFF
--- a/ControlPanel/Programme.xaml.cs
+++ b/ControlPanel/Programme.xaml.cs
@@ -893,7 +893,7 @@ namespace ControlPanel
 		private AsyncVirtualizingCollection<User> GetUsers(string id)
 		{
 			if (userz.ContainsKey(id) == false)
-				userz[id] = new AsyncVirtualizingCollection<User>(new UsersFetcher(WcfClient1, id), 32, 20); ;
+				userz[id] = new AsyncVirtualizingCollection<User>(new UsersFetcher(WcfClient1, id), 32, 20);
 
 			return userz[id];
 		}

--- a/Server/Http/WebSocketHeader.cs
+++ b/Server/Http/WebSocketHeader.cs
@@ -239,8 +239,8 @@ namespace Server.Http
 
 		public override string ToString()
 		{
-			return string.Format("Fin: {0}, Mask: {1}, Opcode: {2}, PayloadLength: {3}",//, MaskingKey: {4:x2}{5:x2}{6:x2}{7:x2}",
-				Fin, Mask, Opcode, PayloadLengthLong//, MaskingKey0, MaskingKey1, MaskingKey2, MaskingKey3);
+            return string.Format("Fin: {0}, Mask: {1}, Opcode: {2}, PayloadLength: {3}",//, MaskingKey: {4:x2}{5:x2}{6:x2}{7:x2}",
+                Fin, Mask, Opcode, PayloadLengthLong);//, MaskingKey0, MaskingKey1, MaskingKey2, MaskingKey3);
 		}
 	}
 }

--- a/Server/Http/WebSocketHeader.cs
+++ b/Server/Http/WebSocketHeader.cs
@@ -240,7 +240,7 @@ namespace Server.Http
 		public override string ToString()
 		{
 			return string.Format("Fin: {0}, Mask: {1}, Opcode: {2}, PayloadLength: {3}",//, MaskingKey: {4:x2}{5:x2}{6:x2}{7:x2}",
-				Fin, Mask, Opcode, PayloadLengthLong, MaskingKey0, MaskingKey1, MaskingKey2, MaskingKey3);
+				Fin, Mask, Opcode, PayloadLengthLong//, MaskingKey0, MaskingKey1, MaskingKey2, MaskingKey3);
 		}
 	}
 }

--- a/Server/Users/CsvUser.cs
+++ b/Server/Users/CsvUser.cs
@@ -64,9 +64,10 @@ namespace Sip.Server.Users
 				QuoteIfReqired(user.CountryCode),
 				QuoteIfReqired(user.PostalCode),
 				QuoteIfReqired(user.WwwHomepage),
-				QuoteIfReqired(user.Title),
+				QuoteIfReqired(user.Title)//,
 				//QuoteIfReqired(user.Company),
-				//QuoteIfReqired(user.PhysicalDeliveryOfficeName));
+				//QuoteIfReqired(user.PhysicalDeliveryOfficeName)
+                );
 		}
 
 		public static string GetFormatDescription()

--- a/Server/Users/CsvUser.cs
+++ b/Server/Users/CsvUser.cs
@@ -65,8 +65,8 @@ namespace Sip.Server.Users
 				QuoteIfReqired(user.PostalCode),
 				QuoteIfReqired(user.WwwHomepage),
 				QuoteIfReqired(user.Title),
-				QuoteIfReqired(user.Company),
-				QuoteIfReqired(user.PhysicalDeliveryOfficeName));
+				//QuoteIfReqired(user.Company),
+				//QuoteIfReqired(user.PhysicalDeliveryOfficeName));
 		}
 
 		public static string GetFormatDescription()


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio: "V3025 Incorrect format. A different number of format items is expected while calling 'Format' function."

UPD: add some

- V3043 The code's operational logic does not correspond with its formatting. The statement is indented to the right, but it is always executed. It is possible that curly brackets are missing. OfficeSipServer Programme.xaml.cs 896